### PR TITLE
Fix overflow in location header

### DIFF
--- a/lib/widgets/location_header.dart
+++ b/lib/widgets/location_header.dart
@@ -15,24 +15,26 @@ class LocationHeader extends StatelessWidget {
             children: [
               const Icon(Icons.location_on, size: 25, color: Color(0xFF112D4E)),
               const SizedBox(width: 8),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'location,',
-                    style:
-                        Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
-                  ),
-                  Text(
-                    'state',
-                    style:
-                        Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
-                  ),
-                ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'location,',
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    Text(
+                      'state',
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- prevent text overflow in `LocationHeader` by wrapping the text column in `Expanded`
- ensure location and state text truncate with ellipsis on narrow screens

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b02177388320a16c79923db0c278